### PR TITLE
Added support for conda build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 build/
 develop-eggs/
 dist/
+dist_conda/
 downloads/
 eggs/
 .eggs/

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,33 @@
+{% set name = "guietta" %}
+{% set version = "0.6.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 6154aa2f763058df5bdbd10a9d3baf0911a1ad803ce7c7b9383baccef5c081bb
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --force-reinstall --no-deps -vv "
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - pyside2
+
+test:
+  imports:
+    - guietta
+    
+about:
+  home: https://github.com/alfiopuglisi/guietta
+  license: MIT
+  license_family: MIT
+  summary: Simple GUI for Python


### PR DESCRIPTION
## What? 
I created a recipe for building a conda package and added the commands to setup.py to follow the workflow of the original PyPi build process. 

## Why?
This will provide an easy build process for conda alongside PyPi. A conda build and upload will also avoid the issue of incompatibility caused by Qt in the case that users use conda over pip.  

## How?
I wrote meta.yaml, which is the recipe for building Conda, and added CondaCommand class to setup.py for automating the build process. The outputs of the build will be in a local directory called dist_conda which will be ignored by gitignore.

## A few other things
* I have manually tested the build process, but I cannot test the upload/install process. 
* pyside2 is available only on conda-forge, and I have specified the channel in the build command. This may potentially have ramification for end-user installation, which likely means to add `-c conda-forge` on the install command.
* I have not updated the documentation, which I can potentially look into if that is something you'd like me to do as well. 